### PR TITLE
Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,10 @@ jobs:
         - sudo apt-get install liblzo2-dev
         - pip install bd2k-python-lib
         - pip install -e .
+        # Have to screw with toil's settings to get the jobs to
+        # actually run properly on such a small VM.
+        - sed -i "s/maxDisk = self.physicalDisk/pass/g" $VIRTUAL_ENV/lib/*/site-packages/toil/batchSystems/singleMachine.py
+        - sed -i "s/maxCores = self.numCores/maxCores = 8/g" $VIRTUAL_ENV/lib/*/site-packages/toil/batchSystems/singleMachine.py
+        - sed -i "s/maxMemory = self.physicalMemory/pass/g" $VIRTUAL_ENV/lib/*/site-packages/toil/batchSystems/singleMachine.py
         # Just go through the test set and make sure it doesn't crash. It's not much, but it's better than nothing.
-        - luigi --module cat RunCat --hal=test_data/vertebrates.hal --ref-genome=mm10 --workers=2 --config=test_data/test.config --work-dir test_install --out-dir test_install --local-scheduler --augustus --augustus-cgp --augustus-pb --assembly-hub
+        - luigi --module cat RunCat --hal=test_data/vertebrates.hal --target-genomes='("hg38", "rn6", "galGal4")' --ref-genome=mm10 --workers=2 --config=test_data/test.config --work-dir test_install --out-dir test_install --local-scheduler --augustus --augustus-cgp --augustus-pb --assembly-hub

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ services:
   - docker
 stages:
   - name: docker-build
+    if: branch = master
   - test
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: required
+language: python
+services:
+  - docker
+stages:
+  - name: docker-build
+  - test
+jobs:
+  include:
+    - stage: docker-build
+      script:
+        - if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then docker build -t quay.io/ucsc_cgl/cat:latest .; fi
+        - if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then docker login --username $QUAY_USERNAME --password $QUAY_PASSWORD quay.io; docker push quay.io/ucsc_cgl/cat:latest; fi
+    - stage: test
+      script:
+        # Enable logging
+        - "sed -i 's/level: .*/level: DEBUG/g' logging.cfg"
+        - sudo apt-get -qq update
+        - sudo apt-get install liblzo2-dev
+        - pip install bd2k-python-lib
+        - pip install -e .
+        # Just go through the test set and make sure it doesn't crash. It's not much, but it's better than nothing.
+        - luigi --module cat RunCat --hal=test_data/vertebrates.hal --ref-genome=mm10 --workers=2 --config=test_data/test.config --work-dir test_install --out-dir test_install --local-scheduler --augustus --augustus-cgp --augustus-pb --assembly-hub

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get install wget -y
 RUN apt-get install git -y
 
 # Kent
-RUN for i in wigToBigWig faToTwoBit gff3ToGenePred genePredToBed genePredToFakePsl bamToPsl transMapPslToGenePred pslPosTarget axtChain chainMergeSort pslMap pslRecalcMatch pslMapPostChain gtfToGenePred genePredToGtf bedtools pslCheck pslCDnaFilter clusterGenes pslToBigPsl bedSort bedToBigBed ; do wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/$i -O /bin/$i ; chmod +x /bin/$i ; done
+RUN for i in wigToBigWig faToTwoBit gff3ToGenePred genePredToBed genePredToFakePsl bamToPsl transMapPslToGenePred pslPosTarget axtChain chainMergeSort pslMap pslRecalcMatch pslMapPostChain gtfToGenePred genePredToGtf bedtools pslCheck pslCDnaFilter clusterGenes pslToBigPsl bedSort bedToBigBed ; do wget -q http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/$i -O /bin/$i ; chmod +x /bin/$i ; done
 
 # bedtools
 RUN apt-get install bedtools -y
@@ -33,7 +33,7 @@ RUN mv samtools /root/tools
 RUN mv htslib /root/tools
 RUN mv bcftools /root/tools
 # Augustus
-RUN wget http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.1.tar.gz
+RUN wget -q http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.1.tar.gz
 RUN tar -xzf augustus-3.3.1.tar.gz
 RUN echo 'COMGENEPRED = true' >> augustus-3.3.1/common.mk
 RUN echo 'SQLITE = true' >> augustus-3.3.1/common.mk
@@ -43,7 +43,7 @@ RUN cd augustus-3.3.1/auxprogs/homGeneMapping/src && sed 's/# BOOST = true/BOOST
 RUN cd augustus-3.3.1/auxprogs && make clean && make
 
 # HDF5
-RUN wget http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.gz
+RUN wget -q http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.gz
 RUN tar xzf hdf5-1.10.1.tar.gz
 RUN cd hdf5-1.10.1 && ./configure --enable-cxx --prefix=/usr 
 RUN cd hdf5-1.10.1 && make && make install
@@ -57,17 +57,12 @@ RUN cd hal && make
 # LibBigWig
 RUN git clone https://github.com/dpryan79/libBigWig.git
 RUN cd libBigWig && make install
-# GSL
-RUN wget ftp://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gsl/gsl-latest.tar.gz 
-RUN tar -xvzpf gsl-latest.tar.gz
-RUN cd gsl* && ./configure
-RUN cd gsl* && make && make install
 # WiggleTools
 RUN git clone https://github.com/Ensembl/WiggleTools.git
 RUN cd WiggleTools && make
 
 # sambamba
-RUN wget https://github.com/biod/sambamba/releases/download/v0.6.7/sambamba_v0.6.7_linux.tar.bz2
+RUN wget -q https://github.com/biod/sambamba/releases/download/v0.6.7/sambamba_v0.6.7_linux.tar.bz2
 RUN tar xvjf sambamba_v0.6.7_linux.tar.bz2
 
 RUN apt-get install python-pip -y
@@ -77,7 +72,7 @@ RUN pip install toil
 RUN pip install pyfasta 
 RUN pip install numpy
 
-RUN wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/blat/blat -O /bin/blat ; chmod +x /bin/blat
+RUN wget -q http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/blat/blat -O /bin/blat ; chmod +x /bin/blat
 
 ENV PATH=$PATH:/augustus-3.3.1/bin:/augustus-3.3.1/scripts:/hal/bin:/WiggleTools/bin:/
 ENV AUGUSTUS_CONFIG_PATH=/augustus-3.3.1/config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get install wget -y
 RUN apt-get install git -y
 
 # Kent
-RUN for i in wigToBigWig faToTwoBit gff3ToGenePred genePredToBed genePredToFakePsl bamToPsl transMapPslToGenePred pslPosTarget axtChain chainMergeSort pslMap pslRecalcMatch pslMapPostChain gtfToGenePred genePredToGtf bedtools blat pslCheck pslCDnaFilter clusterGenes pslToBigPsl bedSort bedToBigBed ; do wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/$i -O /bin/$i ; chmod +x /bin/$i ; done
+RUN for i in wigToBigWig faToTwoBit gff3ToGenePred genePredToBed genePredToFakePsl bamToPsl transMapPslToGenePred pslPosTarget axtChain chainMergeSort pslMap pslRecalcMatch pslMapPostChain gtfToGenePred genePredToGtf bedtools pslCheck pslCDnaFilter clusterGenes pslToBigPsl bedSort bedToBigBed ; do wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/$i -O /bin/$i ; chmod +x /bin/$i ; done
 
 # bedtools
 RUN apt-get install bedtools -y
@@ -26,7 +26,7 @@ RUN cd bcftools && make
 RUN apt-get install libncurses5-dev -y
 # samtools
 RUN git clone git://github.com/samtools/samtools
-RUN cd samtools && make
+RUN cd samtools && make && make install
 # MOVE Directories INTO $HOME/tool
 RUN mkdir /root/tools
 RUN mv samtools /root/tools
@@ -36,6 +36,7 @@ RUN mv bcftools /root/tools
 RUN wget http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.1.tar.gz
 RUN tar -xzf augustus-3.3.1.tar.gz
 RUN echo 'COMGENEPRED = true' >> augustus-3.3.1/common.mk
+RUN echo 'SQLITE = true' >> augustus-3.3.1/common.mk
 RUN cd augustus-3.3.1 && make
 RUN cd augustus-3.3.1/src && make clean all
 RUN cd augustus-3.3.1/auxprogs/homGeneMapping/src && sed 's/# BOOST = true/BOOST = true/g' -i Makefile && sed 's/# SQLITE = true/SQLITE = true/g' -i Makefile
@@ -72,9 +73,12 @@ RUN tar xvjf sambamba_v0.6.7_linux.tar.bz2
 RUN apt-get install python-pip -y
 # toil
 RUN pip install bd2k-python-lib 
-
+RUN pip install toil
 RUN pip install pyfasta 
+RUN pip install numpy
+
+RUN wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/blat/blat -O /bin/blat ; chmod +x /bin/blat
 
 ENV PATH=$PATH:/augustus-3.3.1/bin:/augustus-3.3.1/scripts:/hal/bin:/WiggleTools/bin:/
-ENV AUGUSTUS_CONFIG_PATH=/augustus-3.3.1/scripts
+ENV AUGUSTUS_CONFIG_PATH=/augustus-3.3.1/config/
 ENV LD_LIBRARY_PATH=/libBigWig:$LD_LIBRARY_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get install wget -y
 RUN apt-get install git -y
 
 # Kent
-RUN for i in faToTwoBit gff3ToGenePred genePredToBed genePredToFakePsl bamToPsl transMapPslToGenePred pslPosTarget axtChain chainMergeSort pslMap pslRecalcMatch pslMapPostChain gtfToGenePred genePredToGtf bedtools blat pslCheck pslCDnaFilter clusterGenes pslToBigPsl bedSort bedToBigBed ; do wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/$i -O /bin/$i ; chmod +x /bin/$i ; done
+RUN for i in wigToBigWig faToTwoBit gff3ToGenePred genePredToBed genePredToFakePsl bamToPsl transMapPslToGenePred pslPosTarget axtChain chainMergeSort pslMap pslRecalcMatch pslMapPostChain gtfToGenePred genePredToGtf bedtools blat pslCheck pslCDnaFilter clusterGenes pslToBigPsl bedSort bedToBigBed ; do wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/$i -O /bin/$i ; chmod +x /bin/$i ; done
 
 # bedtools
 RUN apt-get install bedtools -y
@@ -37,15 +37,14 @@ RUN wget http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.1.tar.gz
 RUN tar -xzf augustus-3.3.1.tar.gz
 RUN echo 'COMGENEPRED = true' >> augustus-3.3.1/common.mk
 RUN cd augustus-3.3.1 && make
-#### Unsure pathing ####
-# RUN PATH=$PATH:~/augustus/bin:~/augustus/scripts
-# RUN export AUGUSTUS_CONFIG_PATH=/my_path_to_AUGUSTUS/augustus/config/
 RUN cd augustus-3.3.1/src && make clean all
+RUN cd augustus-3.3.1/auxprogs/homGeneMapping/src && sed 's/# BOOST = true/BOOST = true/g' -i Makefile && sed 's/# SQLITE = true/SQLITE = true/g' -i Makefile
+RUN cd augustus-3.3.1/auxprogs && make clean && make
 
 # HDF5
 RUN wget http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.gz
 RUN tar xzf hdf5-1.10.1.tar.gz
-RUN cd hdf5-1.10.1 && ./configure --prefix=/usr
+RUN cd hdf5-1.10.1 && ./configure --enable-cxx --prefix=/usr 
 RUN cd hdf5-1.10.1 && make && make install
 # sonLib
 RUN git clone git://github.com/benedictpaten/sonLib.git
@@ -53,8 +52,6 @@ RUN git clone git://github.com/benedictpaten/sonLib.git
 RUN git clone git://github.com/glennhickey/hal.git
 RUN /bin/bash -c "pushd sonLib && make && popd"
 RUN cd hal && make
-#### Unsure pathing ####
-# RUN export PATH=hal/bin:${PATH} 
 
 # LibBigWig
 RUN git clone https://github.com/dpryan79/libBigWig.git
@@ -71,3 +68,13 @@ RUN cd WiggleTools && make
 # sambamba
 RUN wget https://github.com/biod/sambamba/releases/download/v0.6.7/sambamba_v0.6.7_linux.tar.bz2
 RUN tar xvjf sambamba_v0.6.7_linux.tar.bz2
+
+RUN apt-get install python-pip -y
+# toil
+RUN pip install bd2k-python-lib 
+
+RUN pip install pyfasta 
+
+ENV PATH=$PATH:/augustus-3.3.1/bin:/augustus-3.3.1/scripts:/hal/bin:/WiggleTools/bin:/
+ENV AUGUSTUS_CONFIG_PATH=/augustus-3.3.1/scripts
+ENV LD_LIBRARY_PATH=/libBigWig:$LD_LIBRARY_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,73 @@
+FROM ubuntu:18.04
+RUN apt-get update
+RUN apt-get install wget -y
+RUN apt-get install git -y
+
+# Kent
+RUN for i in faToTwoBit gff3ToGenePred genePredToBed genePredToFakePsl bamToPsl transMapPslToGenePred pslPosTarget axtChain chainMergeSort pslMap pslRecalcMatch pslMapPostChain gtfToGenePred genePredToGtf bedtools blat pslCheck pslCDnaFilter clusterGenes pslToBigPsl bedSort bedToBigBed ; do wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/$i -O /bin/$i ; chmod +x /bin/$i ; done
+
+# bedtools
+RUN apt-get install bedtools -y
+
+# Augustus dependencies
+RUN apt-get install libboost-all-dev sqlite3 libsqlite3-0 libsqlite3-dev libgsl0-dev lp-solve liblpsolve55-dev bamtools libbamtools-dev -y
+# zlib
+RUN apt-get install liblzma-dev -y
+RUN apt-get install libbz2-dev -y
+# libcurl
+RUN apt-get install libcurl4-openssl-dev -y
+# htslib
+RUN git clone git://github.com/samtools/htslib.git
+RUN cd htslib && make install
+# bcftools
+RUN git clone git://github.com/samtools/bcftools.git 
+RUN cd bcftools && make
+# cureses
+RUN apt-get install libncurses5-dev -y
+# samtools
+RUN git clone git://github.com/samtools/samtools
+RUN cd samtools && make
+# MOVE Directories INTO $HOME/tool
+RUN mkdir /root/tools
+RUN mv samtools /root/tools
+RUN mv htslib /root/tools
+RUN mv bcftools /root/tools
+# Augustus
+RUN wget http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.1.tar.gz
+RUN tar -xzf augustus-3.3.1.tar.gz
+RUN echo 'COMGENEPRED = true' >> augustus-3.3.1/common.mk
+RUN cd augustus-3.3.1 && make
+#### Unsure pathing ####
+# RUN PATH=$PATH:~/augustus/bin:~/augustus/scripts
+# RUN export AUGUSTUS_CONFIG_PATH=/my_path_to_AUGUSTUS/augustus/config/
+RUN cd augustus-3.3.1/src && make clean all
+
+# HDF5
+RUN wget http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.gz
+RUN tar xzf hdf5-1.10.1.tar.gz
+RUN cd hdf5-1.10.1 && ./configure --prefix=/usr
+RUN cd hdf5-1.10.1 && make && make install
+# sonLib
+RUN git clone git://github.com/benedictpaten/sonLib.git
+# HAL
+RUN git clone git://github.com/glennhickey/hal.git
+RUN /bin/bash -c "pushd sonLib && make && popd"
+RUN cd hal && make
+#### Unsure pathing ####
+# RUN export PATH=hal/bin:${PATH} 
+
+# LibBigWig
+RUN git clone https://github.com/dpryan79/libBigWig.git
+RUN cd libBigWig && make install
+# GSL
+RUN wget ftp://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gsl/gsl-latest.tar.gz 
+RUN tar -xvzpf gsl-latest.tar.gz
+RUN cd gsl* && ./configure
+RUN cd gsl* && make && make install
+# WiggleTools
+RUN git clone https://github.com/Ensembl/WiggleTools.git
+RUN cd WiggleTools && make
+
+# sambamba
+RUN wget https://github.com/biod/sambamba/releases/download/v0.6.7/sambamba_v0.6.7_linux.tar.bz2
+RUN tar xvjf sambamba_v0.6.7_linux.tar.bz2

--- a/cat/__init__.py
+++ b/cat/__init__.py
@@ -472,7 +472,7 @@ def success(task):
     """
     pipeline_args = task.get_pipeline_args()
     stats_db = pipeline_args.stats_db
-    cmd = ['toil', 'stats', '--raw', task.job_store]
+    cmd = ['toil', 'stats', '--raw', os.path.abspath(task.job_store)]
     raw = tools.procOps.call_proc(cmd)
     parsed = raw[raw.index('{'):raw.rfind('}') + 1]
     stats = json.loads(parsed)

--- a/cat/__init__.py
+++ b/cat/__init__.py
@@ -2472,10 +2472,9 @@ class DenovoTrack(TrackTask):
                 tools.fileOps.print_row(outf, row)
         tools.procOps.run_proc(['bedSort', tmp.path, tmp.path])
 
-        with track.open('w') as outf:
-            cmd = ['bedToBigBed', '-extraIndex=assignedGeneId,name,name2',
-                   '-type=bed12+8', '-tab', '-as={}'.format(as_file.path), tmp.path, chrom_sizes, '/dev/stdout']
-            tools.procOps.run_proc(cmd, stdout=outf, stderr='/dev/null')
+        cmd = ['bedToBigBed', '-extraIndex=assignedGeneId,name,name2',
+               '-type=bed12+8', '-tab', '-as={}'.format(as_file.path), tmp.path, chrom_sizes, track.path]
+        tools.procOps.run_proc(cmd, stderr='/dev/null')
 
         label = 'AugustusCGP' if self.mode == 'augCGP' else 'AugustusPB'
         description = 'Comparative Augustus' if self.mode == 'augCGP' else 'PacBio Augustus'
@@ -2528,10 +2527,9 @@ class BgpTrack(TrackTask):
                 tools.fileOps.print_row(outf, row)
         tools.procOps.run_proc(['bedSort', tmp.path, tmp.path])
 
-        with track.open('w') as outf:
-            cmd = ['bedToBigBed', '-extraIndex=name,name2,geneId,transcriptId',
-                   '-type=bed12+8', '-tab', '-as={}'.format(as_file.path), tmp.path, chrom_sizes, '/dev/stdout']
-            tools.procOps.run_proc(cmd, stdout=outf, stderr='/dev/null')
+        cmd = ['bedToBigBed', '-extraIndex=name,name2,geneId,transcriptId',
+               '-type=bed12+8', '-tab', '-as={}'.format(as_file.path), tmp.path, chrom_sizes, track.path]
+        tools.procOps.run_proc(cmd, stderr='/dev/null')
 
         with trackdb.open('w') as outf:
             outf.write(bgp_template.format(name='{}_{}'.format(self.label.replace(' ', '_'), self.genome),
@@ -2587,10 +2585,9 @@ class ConsensusTrack(TrackTask):
             outf.write(as_str)
         tools.procOps.run_proc(['bedSort', tmp_gp.path, tmp_gp.path])
 
-        with track.open('w') as outf:
-            cmd = ['bedToBigBed', '-extraIndex=name,name2,txId,geneName,sourceGene,sourceTranscript,alignmentId',
-                   '-type=bed12+21', '-tab', '-as={}'.format(as_file.path), tmp_gp.path, chrom_sizes, '/dev/stdout']
-            tools.procOps.run_proc(cmd, stdout=outf, stderr='/dev/null')
+        cmd = ['bedToBigBed', '-extraIndex=name,name2,txId,geneName,sourceGene,sourceTranscript,alignmentId',
+               '-type=bed12+21', '-tab', '-as={}'.format(as_file.path), tmp_gp.path, chrom_sizes, track.path]
+        tools.procOps.run_proc(cmd, stderr='/dev/null')
 
         with trackdb.open('w') as outf:
             outf.write(consensus_template.format(genome=self.genome, path=os.path.basename(track.path)))
@@ -2637,9 +2634,8 @@ class EvaluationTrack(TrackTask):
         with tmp.open('w') as tmp_handle:
             tools.fileOps.print_rows(tmp_handle, rows)
         tools.procOps.run_proc(['bedSort', tmp.path, tmp.path])
-        with track.open('w') as outf:
-            cmd = ['bedToBigBed', '-type=bed12', '-tab', tmp.path, chrom_sizes, '/dev/stdout']
-            tools.procOps.run_proc(cmd, stdout=outf, stderr='/dev/null')
+        cmd = ['bedToBigBed', '-type=bed12', '-tab', tmp.path, chrom_sizes, track.path]
+        tools.procOps.run_proc(cmd, stderr='/dev/null')
 
         with trackdb.open('w') as outf:
             outf.write(error_template.format(genome=self.genome, path=os.path.basename(track.path)))
@@ -2680,10 +2676,9 @@ class TransMapTrack(TrackTask):
         with as_file.open('w') as outf:
             outf.write(bigpsl)
 
-        with track.open('w') as outf:
-            cmd = ['bedToBigBed', '-type=bed12+13', '-tab', '-extraIndex=name',
-                   '-as={}'.format(as_file.path), tmp.path, chrom_sizes, '/dev/stdout']
-            tools.procOps.run_proc(cmd, stdout=outf, stderr='/dev/null')
+        cmd = ['bedToBigBed', '-type=bed12+13', '-tab', '-extraIndex=name',
+               '-as={}'.format(as_file.path), tmp.path, chrom_sizes, track.path]
+        tools.procOps.run_proc(cmd, stderr='/dev/null')
 
         with trackdb.open('w') as outf:
             outf.write(bigpsl_template.format(name='transmap_{}'.format(self.genome), short_label='transMap',
@@ -2724,9 +2719,8 @@ class AugustusTrack(TrackTask):
                         tools.fileOps.print_row(outf, row)
             tools.procOps.run_proc(['bedSort', tmp, tmp])
             cmd = ['bedToBigBed', '-extraIndex=name,name2,geneId,transcriptId',
-                   '-type=bed12+8', '-tab', '-as={}'.format(as_file), tmp, chrom_sizes, '/dev/stdout']
-            with track.open('w') as outf:
-                tools.procOps.run_proc(cmd, stdout=outf, stderr='/dev/null')
+                   '-type=bed12+8', '-tab', '-as={}'.format(as_file), tmp, chrom_sizes, track.path]
+            tools.procOps.run_proc(cmd, stderr='/dev/null')
 
         with trackdb.open('w') as outf:
             outf.write(bgp_template.format(name='augustus_{}'.format(self.genome), label='AugustusTM(R)',
@@ -2796,9 +2790,8 @@ class SpliceTrack(TrackTask):
 
         tools.procOps.run_proc(['bedSort', tmp.path, tmp.path])
 
-        with track.open('w') as outf:
-            cmd = ['bedToBigBed', '-tab', tmp.path, chrom_sizes, '/dev/stdout']
-            tools.procOps.run_proc(cmd, stdout=outf, stderr='/dev/null')
+        cmd = ['bedToBigBed', '-tab', tmp.path, chrom_sizes, track.path]
+        tools.procOps.run_proc(cmd, stderr='/dev/null')
 
         with trackdb.open('w') as outf:
             outf.write(splice_template.format(genome=self.genome, path=os.path.basename(track.path)))

--- a/cat/__init__.py
+++ b/cat/__init__.py
@@ -449,6 +449,11 @@ class ToilTask(PipelineTask):
             except IOError:
                 shutil.rmtree(job_store)
 
+        if tools.misc.running_in_container():
+            # Caching doesn't work in containers, because the
+            # container filesystems are transient overlays that don't
+            # support hardlinking.
+            toil_args.disableCaching = True
         if toil_args.batchSystem == 'parasol' and toil_args.disableCaching is False:
             raise RuntimeError('Running parasol without disabled caching is a very bad idea.')
         if toil_args.batchSystem == 'parasol' and toil_args.workDir is None:
@@ -2087,8 +2092,8 @@ class Plots(RebuildableTask):
     def get_args(pipeline_args):
         base_dir = os.path.join(pipeline_args.out_dir, 'plots')
         ordered_genomes = tools.hal.build_genome_order(pipeline_args.hal, pipeline_args.ref_genome,
-                                                       genome_subset=pipeline_args.target_genomes,
-                                                       include_ancestors=pipeline_args.annotate_ancestors)
+                                                       pipeline_args.target_genomes,
+                                                       pipeline_args.annotate_ancestors)
         args = tools.misc.HashableNamespace()
         args.ordered_genomes = ordered_genomes
         # plots derived from transMap results

--- a/cat/__init__.py
+++ b/cat/__init__.py
@@ -74,8 +74,8 @@ class PipelineTask(luigi.Task):
     work_dir = luigi.Parameter(default='./cat_work')
     target_genomes = luigi.TupleParameter(default=None)
     annotate_ancestors = luigi.BoolParameter(default=False)
-    binary = luigi.Parameter(default='docker')
-    os.environ['BINARY_MODE'] = binary
+    binary_mode = luigi.ChoiceParameter(choices=["docker", "local"], default='docker',
+                                        significant=False)
     # AugustusTM(R) parameters
     augustus = luigi.BoolParameter(default=False)
     augustus_species = luigi.Parameter(default='human', significant=False)
@@ -201,6 +201,11 @@ class PipelineTask(luigi.Task):
         args.set('annotation_genomes', frozenset(args.cfg['ANNOTATION'].keys()), True)
         args.set('modes', self.get_modes(args), True)
         args.set('augustus_tmr', True if 'augTMR' in args.modes else False, True)
+
+        # We use this environment variable as a bit of global state,
+        # to avoid threading this through in each of the hundreds of
+        # command invocations.
+        os.environ['CAT_BINARY_MODE'] = self.binary
         if self.__class__.__name__ in ['RunCat', 'Augustus', 'AugustusCgp', 'AugustusPb']:
             self.validate_cfg(args)
 

--- a/cat/__init__.py
+++ b/cat/__init__.py
@@ -134,6 +134,11 @@ class PipelineTask(luigi.Task):
 
     def get_pipeline_args(self):
         """returns a namespace of all of the arguments to the pipeline. Resolves the target genomes variable"""
+        # We use this environment variable as a bit of global state,
+        # to avoid threading this through in each of the hundreds of
+        # command invocations.
+        os.environ['CAT_BINARY_MODE'] = self.binary_mode
+
         args = tools.misc.PipelineNamespace()
         args.set('hal', os.path.abspath(self.hal), True)
         args.set('ref_genome', self.ref_genome, True)
@@ -202,10 +207,6 @@ class PipelineTask(luigi.Task):
         args.set('modes', self.get_modes(args), True)
         args.set('augustus_tmr', True if 'augTMR' in args.modes else False, True)
 
-        # We use this environment variable as a bit of global state,
-        # to avoid threading this through in each of the hundreds of
-        # command invocations.
-        os.environ['CAT_BINARY_MODE'] = self.binary
         if self.__class__.__name__ in ['RunCat', 'Augustus', 'AugustusCgp', 'AugustusPb']:
             self.validate_cfg(args)
 

--- a/cat/__init__.py
+++ b/cat/__init__.py
@@ -74,6 +74,8 @@ class PipelineTask(luigi.Task):
     work_dir = luigi.Parameter(default='./cat_work')
     target_genomes = luigi.TupleParameter(default=None)
     annotate_ancestors = luigi.BoolParameter(default=False)
+    binary = luigi.Parameter(default='docker')
+    os.environ['BINARY_MODE'] = binary
     # AugustusTM(R) parameters
     augustus = luigi.BoolParameter(default=False)
     augustus_species = luigi.Parameter(default='human', significant=False)

--- a/cat/__init__.py
+++ b/cat/__init__.py
@@ -191,8 +191,8 @@ class PipelineTask(luigi.Task):
 
         # flags for figuring out which genomes we are going to annotate
         args.set('annotate_ancestors', self.annotate_ancestors, True)
-        args.set('hal_genomes', tools.hal.extract_genomes(self.hal, self.annotate_ancestors), True)
-        target_genomes = tools.hal.extract_genomes(self.hal, self.annotate_ancestors, self.target_genomes)
+        args.set('hal_genomes', tools.hal.extract_genomes(args.hal, self.annotate_ancestors), True)
+        target_genomes = tools.hal.extract_genomes(args.hal, self.annotate_ancestors, self.target_genomes)
         target_genomes = tuple(x for x in target_genomes if x != self.ref_genome)
         args.set('target_genomes', target_genomes, True)
 
@@ -644,7 +644,7 @@ class GenomeFasta(AbstractAtomicFileTask):
 
     def run(self):
         logger.info('Extracting fasta for {}.'.format(self.genome))
-        cmd = ['hal2fasta', self.hal, self.genome]
+        cmd = ['hal2fasta', os.path.abspath(self.hal), self.genome]
         self.run_cmd(cmd)
 
 
@@ -677,7 +677,7 @@ class GenomeSizes(AbstractAtomicFileTask):
 
     def run(self):
         logger.info('Extracting chromosome sizes for {}.'.format(self.genome))
-        cmd = ['halStats', '--chromSizes', self.genome, self.hal]
+        cmd = ['halStats', '--chromSizes', self.genome, os.path.abspath(self.hal)]
         self.run_cmd(cmd)
 
 

--- a/cat/augustus.py
+++ b/cat/augustus.py
@@ -166,7 +166,7 @@ def run_augustus(hint, fasta, tm_tx, cfg_file, start, stop, species, mode, utr):
     cmd = ['augustus', tmp_fasta, '--predictionStart=-{}'.format(start), '--predictionEnd=-{}'.format(start),
            '--extrinsicCfgFile={}'.format(cfg_file), '--hintsfile={}'.format(hints_out), '--UTR={}'.format(int(utr)),
            '--alternatives-from-evidence=0', '--species={}'.format(species), '--allow_hinted_splicesites=atac',
-           '--protein=0', '--softmasking=1']
+           '--protein=0', '--softmasking=1', '--/augustus/verbosity=0']
     aug_output = tools.procOps.call_proc_lines(cmd)
     transcript = munge_augustus_output(aug_output, mode, tm_tx)
     return transcript
@@ -207,7 +207,7 @@ def munge_augustus_output(aug_output, mode, tm_tx):
         return None
     valid_tx = valid_txs[0]
     tx_id = 'aug{}-{}'.format(mode, tm_tx.name)
-    tx_lines = [x.split('\t') for x in aug_output if valid_tx in x]
+    tx_lines = [x.split('\t') for x in aug_output if valid_tx in x and not x.startswith('#')]
     features = {"exon", "CDS", "start_codon", "stop_codon", "tts", "tss"}
     gtf = []
     for chrom, source, feature, start, stop, score, strand, frame, attributes in tx_lines:

--- a/cat/augustus_cgp.py
+++ b/cat/augustus_cgp.py
@@ -214,7 +214,7 @@ def hal2maf(job, input_file_ids, genomes, ref_genome, annotate_ancestors, chrom,
     maf_chunk = tools.fileOps.get_tmp_toil_file()
     genomes = ','.join(genomes)
     cmd = ['hal2maf', '--onlyOrthologs', '--refGenome', ref_genome, '--targetGenomes', genomes,
-           '--refSequence', chrom, '--start', start, '--length', chunk_size, hal, maf_chunk]
+           '--refSequence', chrom, '--start', str(start), '--length', str(chunk_size), hal, maf_chunk]
     if not annotate_ancestors:
         cmd.append('--noAncestors')
     tools.procOps.run_proc(cmd)

--- a/luigi.cfg
+++ b/luigi.cfg
@@ -3,3 +3,13 @@ logging_conf_file = logging.cfg
 
 [resources]
 toil = 5
+
+[retcode]
+# The following return codes are the recommended exit codes for Luigi
+# They are in increasing level of severity (for most applications)
+already_running=10
+missing_data=20
+not_run=25
+task_failed=30
+scheduling_error=35
+unhandled_exception=40

--- a/tools/hal.py
+++ b/tools/hal.py
@@ -3,19 +3,22 @@ Functions for working with HAL files.
 """
 import ete3
 from procOps import call_proc_lines
+from bd2k.util import memoize
 
-
+@memoize
 def get_tree(hal):
     """
     Extracts a Tree object from a HAL
     :param hal: HAL file.
     :return: Tree object
     """
+    import sys, traceback
+    traceback.print_stack()
     cmd = ['halStats', '--tree', hal]
     newick = call_proc_lines(cmd)[0]
     return ete3.Tree(newick, format=1)
 
-
+@memoize
 def build_genome_order(hal, ref_genome, genome_subset=None, include_ancestors=False):
     """
     Constructs an ordered vector of genomes based on genetic distance from a source genome.
@@ -38,7 +41,7 @@ def build_genome_order(hal, ref_genome, genome_subset=None, include_ancestors=Fa
     distances, ordered_names = zip(*ordered)
     return ordered_names
 
-
+@memoize
 def extract_genomes(hal, include_ancestors=False, target_genomes=None):
     """
     Constructs a set of genomes present in this alignment

--- a/tools/misc.py
+++ b/tools/misc.py
@@ -63,6 +63,11 @@ def convert_gp_gtf(gtf_target, gp_target, source='CAT'):
 
 def is_exec(program): 
     """checks if a program is in the global path and executable"""
+    if os.environ.get("CAT_BINARY_MODE") != "local":
+        # We assume containerized versions don't need to check if the
+        # tools are installed--they definitely are, and calling docker
+        # just to run "which" can be surprisingly expensive.
+        return True
     cmd = ['which', program]
     try:
         return procOps.call_proc_lines(cmd)[0].endswith(program)

--- a/tools/misc.py
+++ b/tools/misc.py
@@ -6,6 +6,7 @@ import itertools
 import argparse
 import pysam
 import pandas as pd
+import os
 
 import procOps
 from pipeline import ProcException

--- a/tools/misc.py
+++ b/tools/misc.py
@@ -64,7 +64,7 @@ def convert_gp_gtf(gtf_target, gp_target, source='CAT'):
 
 def is_exec(program): 
     """checks if a program is in the global path and executable"""
-    if os.environ.get("CAT_BINARY_MODE") != "local":
+    if running_in_container():
         # We assume containerized versions don't need to check if the
         # tools are installed--they definitely are, and calling docker
         # just to run "which" can be surprisingly expensive.
@@ -136,3 +136,9 @@ def slice_df(df, ix):
             return r
     except KeyError:
         return pd.DataFrame()
+
+def running_in_container():
+    """
+    Is CAT trying to run tools inside containers?
+    """
+    return os.environ.get("CAT_BINARY_MODE") != "local"

--- a/tools/procOps.py
+++ b/tools/procOps.py
@@ -4,8 +4,13 @@ Wrapper for pipeline.py. Provides a simple interface for compli'cat'ed unix-styl
 """
 import os
 import pipeline
+import pipes
 import sys
 import subprocess
+import logging
+import time
+
+logger = logging.getLogger(__name__)
 
 def cmdLists(cmd):
     """creates dockers commands from lists or a list of lists
@@ -21,15 +26,17 @@ def cmdLists(cmd):
     else:
         return cmd
 
-
 def call_proc(cmd, keepLastNewLine=False):
     """call a process and return stdout, exception with stderr in message.
     The  cmd is either a list of command and arguments, or pipeline, specified by
     a list of lists of commands and arguments."""
     stdout = pipeline.DataReader()
     cmd = cmdLists(cmd)
+    logger.debug('About to run command: %s' % cmd)
+    now = time.time()
     pl = pipeline.Procline(cmd, stdin="/dev/null", stdout=stdout)
     pl.wait()
+    logger.debug('Command %s took %s seconds.' % (cmd, time.time() - now))
     out = stdout.get()
     if (not keepLastNewLine) and (len(out) > 0) and (out[-1] == "\n"):
         out = out[0:-1]

--- a/tools/procOps.py
+++ b/tools/procOps.py
@@ -10,13 +10,16 @@ import subprocess
 def cmdLists(cmd):
     """creates dockers commands from lists or a list of lists
     """
-    if isinstance(cmd[0],list):
-        docList = []
-        for e in cmd:
-            docList.append(getDockerCommand('cat',e))
-        return docList
+    if os.environ.get('BINARY_MODE') is 'docker':
+        if isinstance(cmd[0],list):
+            docList = []
+            for e in cmd:
+                docList.append(getDockerCommand('cat',e))
+            return docList
+        else:
+            return getDockerCommand('cat',cmd)
     else:
-        return getDockerCommand('cat',cmd)
+        return cmd
 
 
 def call_proc(cmd, keepLastNewLine=False):

--- a/tools/procOps.py
+++ b/tools/procOps.py
@@ -19,10 +19,10 @@ def cmdLists(cmd):
         if isinstance(cmd[0],list):
             docList = []
             for e in cmd:
-                docList.append(getDockerCommand('cat',e))
+                docList.append(getDockerCommand('quay.io/ucsc_cgl/cat',e))
             return docList
         else:
-            return getDockerCommand('cat',cmd)
+            return getDockerCommand('quay.io/ucsc_cgl/cat',cmd)
     else:
         return cmd
 

--- a/tools/procOps.py
+++ b/tools/procOps.py
@@ -10,7 +10,7 @@ import subprocess
 def cmdLists(cmd):
     """creates dockers commands from lists or a list of lists
     """
-    if os.environ.get('BINARY_MODE') is 'docker':
+    if os.environ.get('CAT_BINARY_MODE') == 'docker':
         if isinstance(cmd[0],list):
             docList = []
             for e in cmd:

--- a/tools/procOps.py
+++ b/tools/procOps.py
@@ -7,14 +7,25 @@ import pipeline
 import sys
 import subprocess
 
+def cmdLists(cmd):
+    """creates dockers commands from lists or a list of lists
+    """
+    if isinstance(cmd[0],list):
+        docList = []
+        for e in cmd:
+            docList.append(getDockerCommand('cat',e))
+        return docList
+    else:
+        return getDockerCommand('cat',cmd)
+
 
 def call_proc(cmd, keepLastNewLine=False):
     """call a process and return stdout, exception with stderr in message.
     The  cmd is either a list of command and arguments, or pipeline, specified by
     a list of lists of commands and arguments."""
     stdout = pipeline.DataReader()
-    cmd = getDockerCommand('cat',cmd)
-    pl = pipeline.Procline(cmd, stdin="/dev/null", stdout=stdout, stderr='/dev/stderr')
+    cmd = cmdLists(cmd)
+    pl = pipeline.Procline(cmd, stdin="/dev/null", stdout=stdout)
     pl.wait()
     out = stdout.get()
     if (not keepLastNewLine) and (len(out) > 0) and (out[-1] == "\n"):
@@ -34,7 +45,7 @@ def call_proc_lines(cmd):
 def run_proc(cmd, stdin="/dev/null", stdout=None, stderr=None):
     """run a process, with I/O redirection to specified file paths or open
     file objects. None specifies inheriting open file."""
-    cmd = getDockerCommand('cat',cmd)
+    cmd = cmdLists(cmd)
     pl = pipeline.Procline(cmd, stdin=stdin, stdout=stdout, stderr=stderr)
     pl.wait()
 
@@ -44,7 +55,7 @@ def run_proc_code(cmd, stdin="/dev/null", stdout=None, stderr=None):
     file objects. None specifies inheriting open file.  Return exit code rather
     than raising exception"""
     try:
-        cmd = getDockerCommand('cat',cmd)
+        cmd = cmdLists(cmd)
         pl = pipeline.Procline(cmd, stdin=stdin, stdout=stdout, stderr=stderr)
         pl.wait()
     except pipeline.ProcException as ex:
@@ -59,7 +70,7 @@ def popen_catch(command, stdin=None):
     """
     Runs a command and return standard out. TODO: use Mark's tools. I don't think he has this functionality.
     """
-    command = getDockerCommand('cat', command)
+    command = cmdLists(command)
     if stdin is not None:
         process = subprocess.Popen(command,
                                    stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=sys.stderr, bufsize=-1)


### PR DESCRIPTION
Added compatibility to run CAT on Docker by default. Switch options to local using --binary local. Docker container will take over 30 minutes to build due to the size of dependencies. The size of the image is over 3gb. There is a speed impediment relative to working with local libraries. Most of the binaries have been installed using the instructions on the CAT github page and their respective binary READMEs. Currently the Augustus binaries are faulty and as a result the pipeline doesn't work, but Augustus is being fixed. The pathing has also been tweaked in accordance with some of the dependencies, mainly with Augustus. Specifically samtools, bcftools, and htslib binaries have all been moved to /root/tools. There is also continuous integration courtesy of @joelarmstrong. 

For a list of how they were installed:
- Manually installed:
samtools, hdf5, hal and its binaries, WiggleTools and its binaries, bcftools, htslib, Augustus

- Kent Utils, sambamba were precompiled

Everything else were installed using package managers. 