### PR TITLE
CAT requires python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ setup(
     name='cat',
     version='0.1',
     packages=['cat', 'tools'],
+    python_requires='<3.0.0',
     install_requires=[
         'pyfasta>=0.5.2',
         'toil>=3.5',


### PR DESCRIPTION
Python 3 is not supported. Make sure python 2.7 is used. 
Note: Python 2.7 will be deprecated in a year from now. 