### PR TITLE
Pin pandas (>= 0.24.0 currently breaks CAT)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         'toil>=3.5',
         'luigi>=2.5',
         'seaborn>=0.7',
-        'pandas>=0.18',
+        'pandas==0.23.0',
         'frozendict',
         'configobj>=5.0',
         'sqlalchemy>=1.0',


### PR DESCRIPTION
[Pandas made some breaking changes to concat](http://pandas.pydata.org/pandas-docs/version/0.24/whatsnew/v0.24.0.html#concatenation-changes), which breaks any new CAT installs. This pins version 0.23.0 as a quick band-aid.

I think it should be possible to fix CAT so that it works with newer versions of pandas, but I haven't looked into it too closely yet.