### PR TITLE
add singularity support

### DIFF
--- a/cat/__init__.py
+++ b/cat/__init__.py
@@ -78,7 +78,7 @@ class PipelineTask(luigi.Task):
     work_dir = luigi.Parameter(default='./cat_work')
     target_genomes = luigi.TupleParameter(default=None)
     annotate_ancestors = luigi.BoolParameter(default=False)
-    binary_mode = luigi.ChoiceParameter(choices=["docker", "local"], default='docker',
+    binary_mode = luigi.ChoiceParameter(choices=["docker", "local", "singularity"], default='docker',
                                         significant=False)
     # AugustusTM(R) parameters
     augustus = luigi.BoolParameter(default=False)

--- a/cat/__init__.py
+++ b/cat/__init__.py
@@ -215,8 +215,9 @@ class PipelineTask(luigi.Task):
                 raise ToolMissingException('singularity binary not found. Either install it or use a different option for --binary-mode.')
             os.environ['SINGULARITY_PULLFOLDER'] = args.work_dir
             os.environ['SINGULARITY_CACHEDIR'] = args.work_dir
-            check_call(['singularity', 'pull', '--name', 'cat.img',
-                'docker://quay.io/ucsc_cgl/cat:latest'])
+            if not os.path.isfile(os.path.join(args.work_dir, 'cat.img')):
+                check_call(['singularity', 'pull', '--name', 'cat.img',
+                    'docker://quay.io/ucsc_cgl/cat:latest'])
 
         # halStats is run below, before any validate() methods are called.
         if not tools.misc.is_exec('halStats'):

--- a/cat/augustus_cgp.py
+++ b/cat/augustus_cgp.py
@@ -294,6 +294,8 @@ def join_genes(job, gff_chunks):
     with open(raw_gtf_file, 'w') as raw_handle, open(raw_gtf_fofn, 'w') as fofn_handle:
         for (chrom, start, chunksize), chunk in gff_chunks.iteritems():
             local_path = job.fileStore.readGlobalFile(chunk)
+            if os.environ.get('CAT_BINARY_MODE') == 'singularity':
+                local_path = tools.procOps.singularify_arg(local_path)
             fofn_handle.write(local_path + '\n')
             raw_handle.write('## BEGIN CHUNK chrom: {} start: {} chunksize: {}\n'.format(chrom, start, chunksize))
             for line in open(local_path):
@@ -358,6 +360,8 @@ def write_genome_fofn(job, fasta_file_ids):
     with open(genome_fofn, 'w') as outf:
         for genome, file_id in fasta_file_ids.iteritems():
             local_path = job.fileStore.readGlobalFile(file_id)
+            if os.environ.get('CAT_BINARY_MODE') == 'singularity':
+                local_path = tools.procOps.singularify_arg(local_path)
             tools.fileOps.print_row(outf, [genome, local_path])
     return genome_fofn
 

--- a/cat/augustus_pb.py
+++ b/cat/augustus_pb.py
@@ -3,6 +3,7 @@ Runs AugustusPB on a target genome
 """
 import argparse
 import collections
+import os
 
 from toil.fileStore import FileID
 from toil.common import Toil
@@ -144,6 +145,8 @@ def join_genes(job, gff_chunks):
     with open(raw_gtf_file, 'w') as raw_handle, open(raw_gtf_fofn, 'w') as fofn_handle:
         for chunk in gff_chunks:
             local_path = job.fileStore.readGlobalFile(chunk)
+            if os.environ.get('CAT_BINARY_MODE') == 'singularity':
+                local_path = tools.procOps.singularify_arg(local_path)
             fofn_handle.write(local_path + '\n')
             for line in open(local_path):
                 raw_handle.write(line)

--- a/cat/chaining.py
+++ b/cat/chaining.py
@@ -4,6 +4,7 @@ Toil program to generate UCSC chains and nets between two genomes in a HAL file.
 import argparse
 import collections
 import logging
+import os
 
 from toil.fileStore import FileID
 from toil.common import Toil
@@ -108,6 +109,8 @@ def merge(job, chain_files, genome):
     with open(fofn, 'w') as outf:
         for i, file_id in enumerate(chain_files):
             local_path = job.fileStore.readGlobalFile(file_id, userPath='{}.chain'.format(i))
+            if os.environ.get('CAT_BINARY_MODE') == 'singularity':
+                local_path = tools.procOps.singularify_arg(local_path)
             outf.write(local_path + '\n')
     cmd = ['chainMergeSort', '-inputList={}'.format(fofn), '-tempDir={}/'.format(job.fileStore.getLocalTempDir())]
     tmp_chain_file = tools.fileOps.get_tmp_toil_file()

--- a/cat/hgm.py
+++ b/cat/hgm.py
@@ -53,14 +53,20 @@ def hgm(args):
                     supplementary_gff = create_supplementary_gff(args.hints_db, gtf, genome)
                 else:
                     supplementary_gff = create_supplementary_gff(args.hints_db, gtf, genome, args.annotation_gp)
-                tools.fileOps.print_row(outf, [genome, gtf, supplementary_gff])
+                if os.environ.get('CAT_BINARY_MODE') == 'singularity':
+                    tools.fileOps.print_row(outf, [genome] + map(tools.procOps.singularify_arg, [gtf, supplementary_gff]))
+                else:
+                    tools.fileOps.print_row(outf, [genome, gtf, supplementary_gff])
                 supplementary_gffs.append(supplementary_gff)
             if args.ref_genome not in args.in_gtf:  # we are not running CGP, and so have no GTF for the reference
                 dummy_gtf = tools.fileOps.get_tmp_file()
                 tools.fileOps.touch(dummy_gtf)
                 supplementary_gff = create_supplementary_gff(args.hints_db, args.annotation_gtf, args.ref_genome,
                                                              args.annotation_gp)
-                tools.fileOps.print_row(outf, [args.ref_genome, dummy_gtf, supplementary_gff])
+                if os.environ.get('CAT_BINARY_MODE') == 'singularity':
+                    tools.fileOps.print_row(outf, [args.ref_genome] + map(tools.procOps.singularify_arg, [dummy_gtf, supplementary_gff]))
+                else:
+                    tools.fileOps.print_row(outf, [args.ref_genome, dummy_gtf, supplementary_gff])
                 supplementary_gffs.append(supplementary_gff)
             else:
                 dummy_gtf = None

--- a/cat/hints_db.py
+++ b/cat/hints_db.py
@@ -213,6 +213,8 @@ def merge_filtered_bams(job, filtered_file_ids):
     fofn = tools.fileOps.get_tmp_toil_file()
     with open(fofn, 'w') as outf:
         for l in local_paths:
+            if os.environ.get('CAT_BINARY_MODE') == 'singularity':
+                l = tools.procOps.singularify_arg(l)
             outf.write(l + '\n')
     out_bam = tools.fileOps.get_tmp_toil_file()
     cmd = ['samtools', 'merge', '-b', fofn, out_bam]

--- a/tools/misc.py
+++ b/tools/misc.py
@@ -68,14 +68,15 @@ def is_exec(program):
         # We assume containerized versions don't need to check if the
         # tools are installed--they definitely are, and calling docker
         # just to run "which" can be surprisingly expensive. But we do
-        # check for the presence of Docker, since that should take
+        # check for the presence of Docker or Singularity, since that should take
         # only a few ms.
-        cmd = ['which', 'docker']
+        binary_mode = os.environ.get('CAT_BINARY_MODE')
+        cmd = ['which', binary_mode]
         pl = Procline(cmd, stdin='/dev/null', stdout='/dev/null', stderr='/dev/null')
         try:
             pl.wait()
         except ProcException:
-            raise ToolMissingException("Docker not found. Either install Docker, or install CAT's dependencies and use --binary-mode local.")
+            raise ToolMissingException("{0} not found. Either install {0}, or install CAT's dependencies and use --binary-mode local.".format(binary_mode))
     cmd = ['which', program]
     try:
         return procOps.call_proc_lines(cmd)[0].endswith(program)

--- a/tools/misc.py
+++ b/tools/misc.py
@@ -75,13 +75,15 @@ def is_exec(program):
         pl = Procline(cmd, stdin='/dev/null', stdout='/dev/null', stderr='/dev/null')
         try:
             pl.wait()
+            return True
         except ProcException:
             raise ToolMissingException("{0} not found. Either install {0}, or install CAT's dependencies and use --binary-mode local.".format(binary_mode))
-    cmd = ['which', program]
-    try:
-        return procOps.call_proc_lines(cmd)[0].endswith(program)
-    except ProcException:
-        return False
+    else:
+        cmd = ['which', program]
+        try:
+            return procOps.call_proc_lines(cmd)[0].endswith(program)
+        except ProcException:
+            return False
 
 
 def samtools_version():


### PR DESCRIPTION
High-performance compute clusters usually use Singularity rather than Docker for running containerized tasks. I have added functionality to CAT so that it can use Singularity to run executables inside a container rather than Docker.