### PR TITLE
For some users, `joingenes` with the `-g` flag fails. The original ha…

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ As described above, the primary method to executing the pipeline is to follow th
 
 `--target-genomes`: List of genomes to use. If not set, all non-reference genomes in the HAL are used. Due to how `luigi` handles command line tuple parameters, this flag must be formatted as if it was a tuple being passed directly to python, single quoted. So, for example, if your target genomes were Human and Mouse, then you would pass `--target-genomes='("Human", "Mouse")'`. As always with python tuples, if you have only one member, you must have a trailing comma.
 
-`--workers`: Number of local cores to use. If running `toil` in singleMachine mode, care must be taken with the balance of this value and the `--maxCores` parameter.
+`--workers`: Number of local cores to use. If running `toil` in single_machine mode, care must be taken with the balance of this value and the `--maxCores` parameter.
 
 ## Augustus config options
 
@@ -229,7 +229,7 @@ See below for `toil` options shared with the hints database pipeline.
 
 The remaining options are passed directly along to `toil`:
 
-`--batchSystem`: Batch system to use. Defaults to singleMachine. If running in singleMachine mode, no cluster jobs will be submitted. In addition, care must be taken to balance the `--maxCores` field with the `--workers` field with the toil resources in `luigi.cfg`. Basically, you want to make sure that your # of toil resources multiplied by your `--maxCores` is fewer than the total number of system cores you want to use. However, I **highly** recommend using a non-local batch system. See the toil documentation for more.
+`--batchSystem`: Batch system to use. Defaults to single_machine. If running in single_machine mode, no cluster jobs will be submitted. In addition, care must be taken to balance the `--maxCores` field with the `--workers` field with the toil resources in `luigi.cfg`. Basically, you want to make sure that your # of toil resources multiplied by your `--maxCores` is fewer than the total number of system cores you want to use. However, I **highly** recommend using a non-local batch system. See the toil documentation for more.
 
 `--maxCores`: The number of cores each `toil` module will use. If submitting to a batch system, this limits the number of concurrent submissions.
 

--- a/cat/__init__.py
+++ b/cat/__init__.py
@@ -127,7 +127,7 @@ class PipelineTask(luigi.Task):
     in_species_rna_support_only = luigi.BoolParameter(default=False, significant=True)
     rebuild_consensus = luigi.BoolParameter(default=False, significant=True)
     # Toil options
-    batchSystem = luigi.Parameter(default='singleMachine', significant=False)
+    batchSystem = luigi.Parameter(default='single_machine', significant=False)
     maxCores = luigi.IntParameter(default=8, significant=False)
     parasolCommand = luigi.Parameter(default=None, significant=False)
     defaultMemory = luigi.Parameter(default='8G', significant=False)

--- a/cat/augustus_cgp.py
+++ b/cat/augustus_cgp.py
@@ -325,10 +325,19 @@ def join_genes(job, gff_chunks):
                ['sed', ' s/jg/augCGP-/g']]
         tools.procOps.run_proc(cmd, stdout=join_genes_file)
     except:
-        cmd = [['joingenes', '-g', ','.join(files), '-o', '/dev/stdout'],
-               ['grep', '-P', '\tAUGUSTUS\t(exon|CDS|start_codon|stop_codon|tts|tss)\t'],
-               ['sed', ' s/jg/augCGP-/g']]
-        tools.procOps.run_proc(cmd, stdout=join_genes_file)
+        # it is quite like that this will exceed the maximum bash command length. Break it into chunks of 250
+        last_file = None
+        for file_grp in tools.dataOps.grouper(files, 250):
+            # on first iteration, use file_grp only; on subsequent iterations, merge
+            if last_file is not None:
+                file_grp = [last_file] + file_grp
+            intermediate_file = tools.fileOps.get_tmp_toil_file()
+            cmd = [['joingenes', '-g', ','.join(file_grp), '-o', '/dev/stdout'],
+                   ['grep', '-P', '\tAUGUSTUS\t(exon|CDS|start_codon|stop_codon|tts|tss)\t'],
+                   ['sed', ' s/jg/augPB-/g']]
+            tools.procOps.run_proc(cmd, stdout=intermediate_file)
+            last_file = intermediate_file
+        join_genes_file = last_file
 
     # passing the joingenes output through gtfToGenePred then genePredToGtf fixes the sort order for homGeneMapping
     cmd = ['gtfToGenePred', '-genePredExt', join_genes_file, join_genes_gp]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     python_requires='>=3.7.0',
     install_requires=[
         'pyfasta>=0.5.2',
-        'toil>=3.5',
+        'toil>=5.0',
         'luigi>=2.5',
         'seaborn>=0.7',
         'pandas>=1.0',


### PR DESCRIPTION
…ck to bypass this will fail if there are too many files being merged with too long of file paths such that they exceed the maximum length of a bash command. Use this hacky loop to iteratively run `joingenes`.

For issue #218 