### PR TITLE
Requiring toil version 5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN mkdir -p /augustus
 COPY --from=builder /augustus/config /augustus/config
 
 # Python deps
-RUN pip3 install bd2k-python-lib toil[all] pyfasta numpy matplotlib
+RUN pip3 install bd2k-python-lib toil[all]==5.0 pyfasta numpy matplotlib
 
 # make Python 3 primary python
 RUN rm /usr/bin/python

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN mkdir -p /augustus
 COPY --from=builder /augustus/config /augustus/config
 
 # Python deps
-RUN pip3 install bd2k-python-lib toil[all]==5.0 pyfasta numpy matplotlib
+RUN pip3 install bd2k-python-lib toil[all]==5.0 pyfasta numpy matplotlib pandas==1.0
 
 # make Python 3 primary python
 RUN rm /usr/bin/python

--- a/cat/consensus.py
+++ b/cat/consensus.py
@@ -891,7 +891,7 @@ def write_consensus_gps(consensus_gp, consensus_gp_info, final_consensus, tx_dic
     # its possible alternative_source_transcripts did not end up in the final result, so add it
     if 'alternative_source_transcripts' not in gp_info_df.columns:
         gp_info_df['alternative_source_transcripts'] = ['N/A'] * len(gp_info_df)
-    with luigi.LocalTarget(consensus_gp_info).open('wb') as outf:
+    with luigi.LocalTarget(consensus_gp_info).open('w') as outf:
         gp_info_df.to_csv(outf, sep='\t', na_rep='N/A')
     return consensus_gene_dict
 

--- a/cat/consensus.py
+++ b/cat/consensus.py
@@ -891,7 +891,7 @@ def write_consensus_gps(consensus_gp, consensus_gp_info, final_consensus, tx_dic
     # its possible alternative_source_transcripts did not end up in the final result, so add it
     if 'alternative_source_transcripts' not in gp_info_df.columns:
         gp_info_df['alternative_source_transcripts'] = ['N/A'] * len(gp_info_df)
-    with luigi.LocalTarget(consensus_gp_info).open('w') as outf:
+    with luigi.LocalTarget(consensus_gp_info).open('wb') as outf:
         gp_info_df.to_csv(outf, sep='\t', na_rep='N/A')
     return consensus_gene_dict
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     python_requires='>=3.7.0',
     install_requires=[
         'pyfasta>=0.5.2',
-        'toil>=5.0',
+        'toil==5.0',
         'luigi>=2.5',
         'seaborn>=0.7',
         'pandas>=1.0',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         'toil==5.0',
         'luigi>=2.5',
         'seaborn>=0.7',
-        'pandas>=1.0',
+        'pandas==1.0',
         'frozendict',
         'configobj>=5.0',
         'sqlalchemy>=1.0',


### PR DESCRIPTION
Toil 5.2 has breaking changes regarding symlinks. As a temporary fix, require an older version.