### PR TITLE
Fix build errors.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get install -y build-essential libssl-dev libncurses5-dev libcurl4-opens
 libboost-all-dev sqlite3 libsqlite3-0 libsqlite3-dev libgsl0-dev lp-solve liblpsolve55-dev libbamtools-dev wget git
 
 # htslib
-RUN git clone git://github.com/samtools/htslib.git
+RUN git clone --recursive git://github.com/samtools/htslib.git
 RUN cd htslib && make install
 
 # bcftools

--- a/environment.yaml
+++ b/environment.yaml
@@ -69,7 +69,7 @@ dependencies:
   - numpy=1.18.1
   - openblas=0.3.6
   - openssl=1.1.1f
-  - pandas=1.0.3
+  - pandas=1.1.0
   - parasail-python=1.2
   - patsy=0.5.1
   - pcre=8.44

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         'toil==5.0',
         'luigi>=2.5',
         'seaborn>=0.7',
-        'pandas==1.0',
+        'pandas==1.1.0',
         'frozendict',
         'configobj>=5.0',
         'sqlalchemy>=1.0',


### PR DESCRIPTION
1. When building docker image by Dockerfile, "htscodecs" should be cloned recursively.
FYI, the error message showing up is:
```
Step 6/52 : RUN cd htslib && make install
 ---> Running in 8fb018965102
Makefile:118: htscodecs.mk: No such file or directory

...

Error: htscodecs submodule files not present for htslib.
Try running:
    git submodule update --init --recursive
in the top-level htslib directory and then re-run make.


Makefile:438: recipe for target 'htscodecs/htscodecs' failed
make: *** [htscodecs/htscodecs] Error 1
The command '/bin/sh -c cd htslib && make install' returned a non-zero code: 2
```
2. Fix test case failed error, pandas version should be updated.
Reference #244 
Solution is [here](https://github.com/ComparativeGenomicsToolkit/Comparative-Annotation-Toolkit/issues/244#issuecomment-788033802) in the reply by Ian @ifiddes 